### PR TITLE
Test enhancement

### DIFF
--- a/.github/workflows/phpcs.yml
+++ b/.github/workflows/phpcs.yml
@@ -3,10 +3,10 @@ name: PHP Coding Style Checker
 on:
   push:
     branches:
-      - 'master'
+      - '*'
   pull_request:
     branches:
-      - 'master'
+      - '*'
 
 jobs:
 

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -3,10 +3,10 @@ name: build
 on:
   push:
     branches:
-      - 'master'
+      - '*'
   pull_request:
     branches:
-      - 'master'
+      - '*'
 
 jobs:
 
@@ -49,7 +49,7 @@ jobs:
       - name: Run test suite
         run: |
           mkdir -p build/logs
-          ./vendor/bin/phpunit --coverage-clover build/logs/clover.xml
+          ./vendor/bin/phpunit --do-not-cache-result --coverage-clover build/logs/clover.xml
 
       - name: Send to Coveralls
         env:

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -3,10 +3,10 @@ name: PHP Static Analysis
 on:
   push:
     branches:
-      - 'master'
+      - '*'
   pull_request:
     branches:
-      - 'master'
+      - '*'
 
 jobs:
 

--- a/tests/Typist/FunctionsTest.php
+++ b/tests/Typist/FunctionsTest.php
@@ -39,21 +39,21 @@ class FunctionsTest extends TestCase
             nullable_string($typed_string3, null),
             nullable_class(DateTimeInterface::class, $typed_object3, null),
         ];
-        $this->assertSame(false, $typed_bool1);
-        $this->assertSame(false, $typed_bool2);
-        $this->assertSame(null, $typed_bool3);
+        $this->assertFalse($typed_bool1);
+        $this->assertFalse($typed_bool2);
+        $this->assertNull($typed_bool3);
         $this->assertSame(1, $typed_int1);
         $this->assertSame(1, $typed_int2);
-        $this->assertSame(null, $typed_int3);
+        $this->assertNull($typed_int3);
         $this->assertSame(1.1, $typed_float1);
         $this->assertSame(1.1, $typed_float2);
-        $this->assertSame(null, $typed_float3);
+        $this->assertNull($typed_float3);
         $this->assertSame('str', $typed_string1);
         $this->assertSame('str', $typed_string2);
-        $this->assertSame(null, $typed_string3);
+        $this->assertNull($typed_string3);
         $this->assertInstanceOf(DateTime::class, $typed_object1);
         $this->assertInstanceOf(DateTime::class, $typed_object2);
-        $this->assertSame(null, $typed_object3);
+        $this->assertNull($typed_object3);
 
         $this->expectException(TypeError::class);
         $typed_int1 = 'a';

--- a/tests/Typist/TypistTest.php
+++ b/tests/Typist/TypistTest.php
@@ -24,7 +24,7 @@ class TypistTest extends TestCase
         $_ = [
             Typist::bool($typed_value, false),
         ];
-        $this->assertSame(false, $typed_value);
+        $this->assertFalse($typed_value);
         $typed_value = true;
         $this->assertTypeError(function () use (&$typed_value) {
             $typed_value = 1;
@@ -100,7 +100,7 @@ class TypistTest extends TestCase
         $_ = [
             Typist::nullable()::bool($typed_value, false),
         ];
-        $this->assertSame(false, $typed_value);
+        $this->assertFalse($typed_value);
         $typed_value = true;
         $typed_value = null;
         $this->expectException(TypeError::class);


### PR DESCRIPTION
# Changed log

- Using the `*` define all branch to run GitHub Action rather than running on master.
- Add `--do-not-cache-result` option with `./vendor/bin/phpunit` to avoid generating `.phpunit.result.cache` file.
- Using the `assertFalse` to assert expected is `false`.
- Using the `assertNull` to assert expected is `null`.